### PR TITLE
Add `receiptSettings` to CheckRedeemOnly (ADV-23536)

### DIFF
--- a/openapi/components/schemas/checkRedeemOnly.yaml
+++ b/openapi/components/schemas/checkRedeemOnly.yaml
@@ -29,6 +29,12 @@ properties:
   rewardSelectionMode:
     $ref: './rewardSelectionMode.yaml'
     description: Identifies whether to use automatic, manual, or applicable_rewards reward selection.
+  receiptSettings:
+    type: array
+    description: List of receipt settings
+    minimum: 1
+    items:
+      $ref: './receiptSettings.yaml'
 
 required:
 - merchantId
@@ -38,3 +44,4 @@ required:
 - terminal
 - operator
 - rewardSelectionMode
+- receiptSettings


### PR DESCRIPTION
# Motivations
While not listed on the Paytronix documentation, `receiptSettings` is required on the CheckRedeemOnly endpoint

# Modifications
- Add `receiptSettings` to the CheckRedeemOnly spec

https://centeredge.atlassian.net/browse/ADV-23536
