### PR TITLE
Allow error messages in AddRedeemReply (ADV-23829)

### DIFF
--- a/openapi/components/schemas/addRedeemAuthorizedSuccess.yaml
+++ b/openapi/components/schemas/addRedeemAuthorizedSuccess.yaml
@@ -1,0 +1,4 @@
+type: object
+allOf:
+- $ref: './authorizedSuccess.yaml'
+- $ref: './addRedeemSuccessProperties.yaml'

--- a/openapi/components/schemas/addRedeemAuthorizedVariantSuccess.yaml
+++ b/openapi/components/schemas/addRedeemAuthorizedVariantSuccess.yaml
@@ -1,0 +1,4 @@
+type: object
+allOf:
+- $ref: './authorizedVariantSuccess.yaml'
+- $ref: './addRedeemSuccessProperties.yaml'

--- a/openapi/components/schemas/addRedeemReply.yaml
+++ b/openapi/components/schemas/addRedeemReply.yaml
@@ -1,6 +1,6 @@
 type: object
 allOf:
-  - $ref: './authorizedSuccess.yaml'
+  - $ref: './transactionReply.yaml'
 properties:
   addWalletContents:
     type: array

--- a/openapi/components/schemas/addRedeemReply.yaml
+++ b/openapi/components/schemas/addRedeemReply.yaml
@@ -1,6 +1,18 @@
 type: object
-allOf:
-  - $ref: './transactionReply.yaml'
+oneOf:
+  - $ref: './authorizedSuccess.yaml'
+  - $ref: './authorizedVariantSuccess.yaml'
+  - $ref: './transactionDenied.yaml'
+  - $ref: './userDataError.yaml'
+  - $ref: './transactionFailure.yaml'
+discriminator:
+  propertyName: result
+  mapping:
+    authorizedSuccess: './authorizedSuccess.yaml'
+    authorizedVariantSuccess: './authorizedVariantSuccess.yaml'
+    denied: './transactionDenied.yaml'
+    userDataError: './userDataError.yaml'
+    failure: './transactionFailure.yaml'
 properties:
   addWalletContents:
     type: array

--- a/openapi/components/schemas/addRedeemReply.yaml
+++ b/openapi/components/schemas/addRedeemReply.yaml
@@ -1,28 +1,15 @@
 type: object
 oneOf:
-  - $ref: './authorizedSuccess.yaml'
-  - $ref: './authorizedVariantSuccess.yaml'
+  - $ref: './addRedeemAuthorizedSuccess.yaml'
+  - $ref: './addRedeemAuthorizedVariantSuccess.yaml'
   - $ref: './transactionDenied.yaml'
   - $ref: './userDataError.yaml'
   - $ref: './transactionFailure.yaml'
 discriminator:
   propertyName: result
   mapping:
-    authorizedSuccess: './authorizedSuccess.yaml'
-    authorizedVariantSuccess: './authorizedVariantSuccess.yaml'
+    authorizedSuccess: './addRedeemAuthorizedSuccess.yaml'
+    authorizedVariantSuccess: './addRedeemAuthorizedVariantSuccess.yaml'
     denied: './transactionDenied.yaml'
     userDataError: './userDataError.yaml'
     failure: './transactionFailure.yaml'
-properties:
-  addWalletContents:
-    type: array
-    items:
-      $ref: './addWalletContents.yaml'
-  redeemWalletContents:
-    type: array
-    items:
-      $ref: './redeemWalletContents.yaml'
-  changedWalletContents:
-    type: array
-    items:
-      $ref: './changedWalletContents.yaml'

--- a/openapi/components/schemas/addRedeemSuccessProperties.yaml
+++ b/openapi/components/schemas/addRedeemSuccessProperties.yaml
@@ -1,0 +1,13 @@
+properties:
+  addWalletContents:
+    type: array
+    items:
+      $ref: './addWalletContents.yaml'
+  redeemWalletContents:
+    type: array
+    items:
+      $ref: './redeemWalletContents.yaml'
+  changedWalletContents:
+    type: array
+    items:
+      $ref: './changedWalletContents.yaml'


### PR DESCRIPTION
Motivation
------------
The reply to addRedeem requests may also include error messages inherited from TransactionReply, but this is not currently available in the spec.

Modifications
---------------
Add appropriate model types inherited from the other models in such a way that Yardarm handles it correctly as well.

https://centeredge.atlassian.net/browse/ADV-23829
