### PR TITLE
Make PaytronixApi UserDataError ErrorCode a string (ADV-23833)

### DIFF
--- a/openapi/components/schemas/userDataError.yaml
+++ b/openapi/components/schemas/userDataError.yaml
@@ -5,7 +5,7 @@ properties:
     description: Result of the call. Must be 'userDataError'.
     example: userDataError
   errorCode:
-    type: integer
+    type: string
   errorMessage:
     type: string
   responseCode:
@@ -42,7 +42,7 @@ properties:
   tierCode:
     type: string
     description: Code to identify the tier, e.g. 0.
-    example: 0  
+    example: 0
   cardTemplateCode:
     type: integer
     description: Code to uniquely identify the card template.
@@ -67,7 +67,7 @@ properties:
     type: number
     format: decimal
     description: Balance of Stored Value wallet.
-    example: 25.00 
+    example: 25.00
   svTransactionAmount:
     type: number
     format: decimal
@@ -77,7 +77,7 @@ properties:
     type: number
     format: decimal
     description: Previous balance of Stored Value wallet.
-    example: 5.00 
+    example: 5.00
   svriFlag:
     type: boolean
     description: Indicates whether Stored Value balance information is present in reply
@@ -116,4 +116,4 @@ required:
   - maskedCardNumber
   - cardTemplateCode
   - cardTemplateName
-  - pxTransactionId  
+  - pxTransactionId


### PR DESCRIPTION
Motivation
----------
The errorCode returned in userDataError is really a string, not a number.

Modifications
-------------
Use the correct type.

https://centeredge.atlassian.net/browse/ADV-23833
