### PR TITLE
Adjust success return type on SMS enroll (ADV-23955)

### DIFF
--- a/openapi/components/responses/smsEnrollResponse.yaml
+++ b/openapi/components/responses/smsEnrollResponse.yaml
@@ -6,5 +6,5 @@ oneOf:
 discriminator:
   propertyName: result
   mapping:
-    authorizedSuccess: '../schemas/smsEnrollSuccess.yaml'
+    success: '../schemas/smsEnrollSuccess.yaml'
     failure: '../schemas/error.yaml'


### PR DESCRIPTION
Motivation
----------
The discriminator is currently incorrect.

Modifications
-------------
Switch it to match the API docs.

https://centeredge.atlassian.net/browse/ADV-23955
