### PR TITLE
Adjust rewardType & discountItemId in redeemWalletContents (ADV-23971)

### DIFF
--- a/openapi/components/schemas/redeemWalletContents.yaml
+++ b/openapi/components/schemas/redeemWalletContents.yaml
@@ -19,7 +19,5 @@ properties:
     example: 1.25
 
 required:
-  - rewardType
-  - discountItemId
   - walletCode
   - quantity


### PR DESCRIPTION
# Motivations
After a Paytronix certification it was requested that these two fields not be included in any API calls when dealing with Paytronix Gift

# Modifications
- Remove `rewardType` and `discountItemId` from the required list in `redeemWwalletContents`, `addRedeem` uses this object. Without them being required, they should no longer be included in any api calls if they aren't included.

https://centeredge.atlassian.net/browse/ADV-23971
