### PR TITLE
Downgrade to Yardarm 0.6.0-beta0001 (ADV-24297)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
       with:
         dotnet-version: 8.0.x
     - name: Install Yardarm
-      run: dotnet tool install --global --version 0.6.0-beta0002 Yardarm.CommandLine
+      run: dotnet tool install --global --version 0.6.0-beta0001 Yardarm.CommandLine
 
     - name: Build
       run: yardarm generate -i ./dist/centeredge-paytronixapi.yaml -f net8.0 --embed --nupkg ./dist/ -n CenterEdge.PaytronixApi -v ${{ needs.buildSpec.outputs.nuGetVersionV2 }} -x Yardarm.SystemTextJson Yardarm.MicrosoftExtensionsHttp --repository-url https://github.com/${GITHUB_REPOSITORY}.git --repository-commit ${GITHUB_SHA}


### PR DESCRIPTION
Motivation
----------
The System.Text.Json 9.0.0 dependency is causing some incompatibilities.

Modifications
-------------
Downgrade.

https://centeredge.atlassian.net/browse/ADV-24297
