### PR TITLE
Add postal code to SetUserFields (PHNX-16300)

### DIFF
--- a/openapi/components/schemas/setUserFields.yaml
+++ b/openapi/components/schemas/setUserFields.yaml
@@ -86,6 +86,13 @@ properties:
       Must be a valid two-letter state or province code for the country.
       If the country is not specified, US is assumed
     example: ["NC"]
+  postalCode:
+    type: array
+    items:
+      type: string
+    description: |
+      Must be a valid postal code for the given country and state/province
+    example: [ "NC" ]
   country:
     type: array
     items:

--- a/openapi/components/schemas/setUserFields.yaml
+++ b/openapi/components/schemas/setUserFields.yaml
@@ -92,7 +92,7 @@ properties:
       type: string
     description: |
       Must be a valid postal code for the given country and state/province
-    example: [ "NC" ]
+    example: [ "37115" ]
   country:
     type: array
     items:


### PR DESCRIPTION
Motivation
---
Paytronix certification failed us for not sending postal code

Modification
---
Add postal code to spec so we can forward it

https://centeredge.atlassian.net/browse/PHNX-16300
